### PR TITLE
Updated CSS to hide block in moodle 2.7/Totara

### DIFF
--- a/block_uicustomcss.php
+++ b/block_uicustomcss.php
@@ -1,13 +1,13 @@
 <?php  /*
- _   _ _____   _____           _                    _____  _____ _____ 
+ _   _ _____   _____           _                    _____  _____ _____
 | | | |_   _| /  __ \         | |                  /  __ \/  ___/  ___|
-| | | | | |   | /  \/_   _ ___| |_ ___  _ __ ___   | /  \/\ `--.\ `--. 
+| | | | | |   | /  \/_   _ ___| |_ ___  _ __ ___   | /  \/\ `--.\ `--.
 | | | | | |   | |   | | | / __| __/ _ \| '_ ` _ \  | |     `--. \`--. \
 | |_| |_| |_  | \__/\ |_| \__ \ || (_) | | | | | | | \__/\/\__/ /\__/ /
- \___/ \___/   \____/\__,_|___/\__\___/|_| |_| |_|  \____/\____/\____/ 
+ \___/ \___/   \____/\__,_|___/\__\___/|_| |_| |_|  \____/\____/\____/
  Copyright 2014 dandavis/University of Illinois at Urbana Champaign
  Add custom css code or import whole sheets via https url
- * 
+ *
  * This plugin is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
@@ -30,41 +30,44 @@ class block_uicustomcss extends block_base {
 	public function init() {
 		$this->title = get_string('uicustomcss', 'block_uicustomcss');
 	}
-		
-			
+
+
 	public function get_content() {
-		
+
 		// try to re-use cached copy:
 		if ($this->content) {
 		  return $this->content;
 		}
-			 
+
 		$this->content         =  new stdClass; // make a new content object
 		$this->content->text = ""; // make a new blank output string
-		
-		
+
+
 		if($this->config){ // url and or css code has been entered in config form
-		
-			if($this->config->cssurl){ //if url given, put on own sheet to prevent interference, prevent xss by removing tag openers: 
+
+			if($this->config->cssurl){ //if url given, put on own sheet to prevent interference, prevent xss by removing tag openers:
 				$this->content->text .= '<style> @import url("'. str_replace ("<", "", $this->config->cssurl ) .'");</style>';
 			}
-			
+
 			// inject a config menu script, some default css to hide un-used css block menu, and the actual css given in the config menu:
 			$this->content->text.= ' <script>setTimeout(function(){
-				if(self.id_bui_pagetypepattern && self.id_bui_pagetypepattern.selectedIndex==2 ){ 
+				if(self.id_bui_pagetypepattern && self.id_bui_pagetypepattern.selectedIndex==2 ){
 					self.id_bui_pagetypepattern.selectedIndex=0;
-				}}, 40);</script> 
-				<style>' .  
-					str_replace ("<", "", $this->config->csscode ) . 
-					' #sidebar .block_uicustomcss {display:none; } body.editing #sidebar .block_uicustomcss {display:block; }  
+				}}, 40);</script>
+				<style>' .
+					str_replace ("<", "", $this->config->csscode ) .
+					' #sidebar .block_uicustomcss, #block-region-side-pre .block_uicustomcss, #block-region-side-post .block_uicustomcss
+						{display:none; }
+					body.editing #sidebar .block_uicustomcss,body.editing #block-region-side-pre .block_uicustomcss, body.editing #block-region-side-post .block_uicustomcss
+						{display:block; }
 				</style>';
-		
+
 		} // end if config?
-		
+
 		$this->content->footer = '';
 
 		return $this->content;
 	} // end get_content()
-  
- 
+
+
 }   // Here's the closing bracket for the class definition

--- a/version.php
+++ b/version.php
@@ -1,13 +1,13 @@
 <?php /*
- _   _ _____   _____           _                    _____  _____ _____ 
+ _   _ _____   _____           _                    _____  _____ _____
 | | | |_   _| /  __ \         | |                  /  __ \/  ___/  ___|
-| | | | | |   | /  \/_   _ ___| |_ ___  _ __ ___   | /  \/\ `--.\ `--. 
+| | | | | |   | /  \/_   _ ___| |_ ___  _ __ ___   | /  \/\ `--.\ `--.
 | | | | | |   | |   | | | / __| __/ _ \| '_ ` _ \  | |     `--. \`--. \
 | |_| |_| |_  | \__/\ |_| \__ \ || (_) | | | | | | | \__/\/\__/ /\__/ /
- \___/ \___/   \____/\__,_|___/\__\___/|_| |_| |_|  \____/\____/\____/ 
+ \___/ \___/   \____/\__,_|___/\__\___/|_| |_| |_|  \____/\____/\____/
  Copyright 2014 dandavis/University of Illinois at Urbana Champaign
  Add custom css code or import whole sheets via https url
- * 
+ *
  * This plugin is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
@@ -21,11 +21,11 @@
  *  You should have received a copy of the GNU General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
+
  /**
  * UI Custom CSS
  *
- * The uicustomcss module is designed to allow instructors of a course to create custom css that will 
+ * The uicustomcss module is designed to allow instructors of a course to create custom css that will
  * only be applied to their course and, if they choose, other pages inside their course.
  *
  * @package    block_uicustomcss
@@ -35,8 +35,8 @@
  */
 
 
-$plugin->version = 2012062899;  // YYYYMMDDHH (year, month, day, 24-hr time)
+$plugin->version = 2018072011;  // YYYYMMDDHH (year, month, day, 24-hr time)
 $plugin->requires = 2010112400; // YYYYMMDDHH (This is the release version for Moodle 2.0)
-$plugin->release   = 1.0;       // The human readable version number of the plugin
-$plugin->maturity = MATURITY_STABLE; // This is considered as ready for production sites. 
+$plugin->release   = 1.1;       // The human readable version number of the plugin
+$plugin->maturity = MATURITY_STABLE; // This is considered as ready for production sites.
 $plugin->component = 'block_uicustomcss';


### PR DESCRIPTION
Added #block-region-side-pre & #block-region-side-post so block hides and shows in Moodle 2.7/Totara 2.7 as the #sidebar is not used. Updated version number

Would have liked to hide the space of the sidebar when nothing in there but not sure how to do that as if no other blocks the space for sidebar remains